### PR TITLE
Print docker binary output in error annotation

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"

--- a/main.go
+++ b/main.go
@@ -14,7 +14,7 @@ import (
 func main() {
 	err := mainE(context.Background())
 	if err != nil {
-		panic(fmt.Sprintf("%s\n", microerror.JSON(err)))
+		panic(microerror.JSON(err))
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -14,7 +14,7 @@ import (
 func main() {
 	err := mainE(context.Background())
 	if err != nil {
-		panic(fmt.Sprintf("%#v\n", microerror.JSON(err)))
+		panic(fmt.Sprintf("%s\n", microerror.JSON(err)))
 	}
 }
 

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
-	"syscall"
 
 	"github.com/giantswarm/microerror"
 )
@@ -170,11 +169,6 @@ func binaryExists() bool {
 	err := cmd.Run()
 
 	if err != nil {
-		if exitError, ok := err.(*exec.ExitError); ok {
-			if exitError.Sys().(syscall.WaitStatus).ExitStatus() == 0 {
-				return true
-			}
-		}
 		return false
 	}
 	return true

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -178,7 +178,7 @@ func executeCmd(binary string, args []string) error {
 		exitCode = exitErr.ExitCode()
 	}
 	if err != nil {
-		return microerror.Maskf(executionFailedError, "command execution failed with exit code = %d error = %#q and output = %#q", exitCode, err, output)
+		return microerror.Maskf(executionFailedError, "command execution failed with exit code = %d error = %#q and output:\n\n%s", exitCode, err, output)
 	}
 
 	return nil

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -178,7 +178,7 @@ func executeCmd(binary string, args []string) error {
 		exitCode = exitErr.ExitCode()
 	}
 	if err != nil {
-		return microerror.Maskf(executionFailedError, "command execution failed with exit code = %d error = %#q and output: %#q", exitCode, err, output)
+		return microerror.Maskf(executionFailedError, "command execution failed with exit code = %d error = %#q and output = %#q", exitCode, err, output)
 	}
 
 	return nil

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -1,9 +1,9 @@
 package registry
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
-	"os"
 	"os/exec"
 
 	"github.com/giantswarm/microerror"
@@ -164,32 +164,21 @@ func (r *Registry) RepositoryTagExists(repo, tag string) (bool, error) {
 	return stringInSlice(tag, tags), nil
 }
 
-func binaryExists() bool {
-	cmd := exec.Command(dockerBinaryName)
-	err := cmd.Run()
-
-	if err != nil {
-		return false
-	}
-	return true
-}
-
 func executeCmd(binary string, args []string) error {
-	if !binaryExists() {
-		return microerror.Mask(executionFailedError)
-	}
-
 	cmd := exec.Command(
 		binary,
 		args...,
 	)
 
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
+	var exitCode int = -1
+	var exitErr *exec.ExitError
 
-	err := cmd.Run()
+	output, err := cmd.CombinedOutput()
+	if errors.As(err, &exitErr) {
+		exitCode = exitErr.ExitCode()
+	}
 	if err != nil {
-		return microerror.Mask(err)
+		return microerror.Maskf(executionFailedError, "command execution failed with exit code = %d error = %#q and output: %#q", exitCode, err, output)
 	}
 
 	return nil


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/12061

The final error is far from being beautiful, but when running multiple go
routines we need an output in the single place.