### PR TITLE
Structure output printing

### DIFF
--- a/pkg/quay/quay.go
+++ b/pkg/quay/quay.go
@@ -50,8 +50,6 @@ func (q *Quay) Authorize(user, password string) error {
 }
 
 func (q *Quay) ListRepositories() ([]string, error) {
-	fmt.Printf("Reading list of quay repositories in %#q namespace...\n", q.namespace)
-
 	var reposToSync []string
 
 	req, err := http.NewRequest("GET", repositoryEndpoint, nil)
@@ -95,8 +93,6 @@ func (q *Quay) ListRepositories() ([]string, error) {
 }
 
 func (q *Quay) ListTags(repository string) ([]string, error) {
-	fmt.Printf("\nReading list of tags from source registry for %#q repository...\n", repository)
-
 	endpoint := fmt.Sprintf("%s/v2/%s/tags/list", registryEndpoint, repository)
 
 	type tagsJSON struct {

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -40,8 +40,6 @@ func New(c Config) (*Registry, error) {
 }
 
 func (r *Registry) Login(ctx context.Context, user, password string) error {
-	fmt.Printf("Logging in destination container registry...\n")
-
 	args := []string{"login", r.name, "-u", user, "-p", password}
 
 	err := executeCmd(dockerBinaryName, args)
@@ -58,8 +56,6 @@ func (r *Registry) Login(ctx context.Context, user, password string) error {
 }
 
 func (r *Registry) Logout(ctx context.Context) error {
-	fmt.Printf("Logging out of destination container registry...\n")
-
 	var args []string
 
 	if r.name == "" {
@@ -130,8 +126,6 @@ func (r *Registry) RemoveImage(ctx context.Context, repo, tag string) error {
 func RetagImage(repo, tag, srcRegistry, dstRegistry string) error {
 	srcImage := fmt.Sprintf("%s/%s:%s", srcRegistry, repo, tag)
 	dstImage := fmt.Sprintf("%s/%s:%s", dstRegistry, repo, tag)
-
-	fmt.Printf("Retagging image %#q into %#q\n", srcImage, dstImage)
 
 	args := []string{"tag", srcImage, dstImage}
 


### PR DESCRIPTION
It looks like this now:

Towards https://github.com/giantswarm/giantswarm/issues/12061

```
Source registry       = `quay.io`
Destination registry  = `docker.io`
Logging in destination container registry...
There are 4 repositories to sync.

Repository [1/4] = `giantswarm/azure-operator`: Reading list of tags from source registry...
Repository [1/4] = `giantswarm/azure-operator`: Reading list of tags from destination registry...
Repository [1/4] = `giantswarm/azure-operator`: There are 100 tags to sync.
Repository [1/4] = `giantswarm/azure-operator`: Tag [1/100] = `4.0.0-f6610752fa42e0c18433ee90ba8092499d47e417`: Retagging...
Repository [1/4] = `giantswarm/azure-operator`: Tag [2/100] = `4.0.0-977a170bdadb06fb6fbecdf9cfe8fbdeefd8d228`: Retagging...
```