### PR TITLE
Remove images after sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Synchronize all tags instead of just releases.
 - Fix tags listing in azure container registry.
 - Fix tags listing in dockerhub container registry.
+- Remove images after all tags synced, not after every tag.
 
 ## [0.3.0] - 2020-07-09
 

--- a/cmd/sync/runner.go
+++ b/cmd/sync/runner.go
@@ -164,7 +164,7 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 
 		}
 
-		for tagIndex, tag := range tagsToSync {
+		for _, tag := range tagsToSync {
 			err = srcRegistry.RemoveImage(ctx, repo, tag)
 			if err != nil {
 				return microerror.Mask(err)

--- a/cmd/sync/runner.go
+++ b/cmd/sync/runner.go
@@ -157,16 +157,18 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 				return microerror.Mask(err)
 			}
 
-			err = srcRegistry.RemoveImage(ctx, repo, tag)
-			if err != nil {
-				return microerror.Mask(err)
-			}
-
 			err = dstRegistry.Push(ctx, repo, tag)
 			if err != nil {
 				return microerror.Mask(err)
 			}
 
+		}
+
+		for tagIndex, tag := range tagsToSync {
+			err = srcRegistry.RemoveImage(ctx, repo, tag)
+			if err != nil {
+				return microerror.Mask(err)
+			}
 			err = dstRegistry.RemoveImage(ctx, repo, tag)
 			if err != nil {
 				return microerror.Mask(err)


### PR DESCRIPTION
This change makes syncing less consistent but much-much faster. 
As with big images like 1GB, we first pull it (all layers), retag, remove and move to the next tag. And then move again to the next version. And pull 1Gb again.

If we clean-up tags after all images synced, it takes less time to pull images as most of the layers are already present in fs