### PR TITLE
Bring helm resource names to the latest standard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix tags listing in azure container registry.
 - Fix tags listing in dockerhub container registry.
+- Make helm resource names unique per release.
 
 ## [0.3.0] - 2020-07-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Make helm resource names unique per release.
+
 ## [0.4.0] - 2020-07-17
 
 ### Added
@@ -24,7 +28,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix tags listing in azure container registry.
 - Fix tags listing in dockerhub container registry.
-- Make helm resource names unique per release.
 
 ## [0.3.0] - 2020-07-09
 

--- a/helm/crsync/templates/_resource.tpl
+++ b/helm/crsync/templates/_resource.tpl
@@ -8,7 +8,7 @@ characters for resource names, the stem is truncated to 47 characters to leave
 room for such suffix.
 */}}
 {{- define "resource.default.name" -}}
-{{- printf "%s-%s" .Chart.Name .Values.destinationRegistry.name | replace "." "-" | trunc 47 | trimSuffix "-" -}}
+{{- .Release.Name | replace "." "-" | trunc 47 | trimSuffix "-" -}}
 {{- end -}}
 
 {{- define "resource.networkPolicy.name" -}}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/12061

This also makes it possible to test it. Otherwise helm complains about already
existing PSP.