### PR TITLE
Fix listing tags in quay.io

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Fix listing tags in `quay.io` registry.
+
 ## [0.5.2] - 2020-07-22
 
 ### Added


### PR DESCRIPTION
I don't know what did I test, but listing tags with token doesn't work for v2 endpoint.
(I actually tested only appearance of private repos in list for synchronization)
That's why switching to v1

Towards https://github.com/giantswarm/giantswarm/issues/12299