### PR TITLE
Expose metrics for Prometheus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix network policy and service to be visible to Prometheus as a target.
+
 ## [0.5.2] - 2020-07-22
 
 ### Added

--- a/helm/crsync/templates/deployment.yaml
+++ b/helm/crsync/templates/deployment.yaml
@@ -70,6 +70,10 @@ spec:
           limits:
             cpu: 250m
             memory: 100Mi
+        ports:
+        - name: prometheus-metrics
+          port: {{ .Values.flags.metricsPort }}
+          targetPort: {{ .Values.flags.metricsPort }}
       serviceAccount: {{ include "resource.default.name"  . }}
       serviceAccountName: {{ include "resource.default.name"  . }}
       volumes:

--- a/helm/crsync/templates/np.yaml
+++ b/helm/crsync/templates/np.yaml
@@ -9,6 +9,10 @@ spec:
   podSelector:
     matchLabels:
       {{- include "labels.selector" . | nindent 6 }}
+  ingress:
+  - ports:
+    - port: {{ .Values.flags.metricsPort }}
+      protocol: TCP
   egress:
   - {}
   policyTypes:

--- a/helm/crsync/templates/service.yaml
+++ b/helm/crsync/templates/service.yaml
@@ -6,12 +6,13 @@ metadata:
   labels:
     {{- include "labels.common" . | nindent 4 }}
   annotations:
-    prometheus.io/scrape: "true"
-    prometheus.io/port: {{ .Values.metricsPort | quote }}
+    giantswarm.io/monitoring: "true"
+    giantswarm.io/monitoring-path: "metrics"
+    giantswarm.io/monitoring-port: {{ .Values.flags.metricsPort | quote }}
 spec:
   ports:
     - name: prometheus-metrics
-      port: {{ .Values.metricsPort }}
-      targetPort: {{ .Values.metricsPort }}
+      port: {{ .Values.flags.metricsPort }}
+      targetPort: {{ .Values.flags.metricsPort }}
   selector:
     {{- include "labels.selector" . | nindent 4 }}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/12315

- Annotations make Prometheus discover the service
- NetwotkPolicy now allows Prometheus to connect to metrics port
- tested
![image](https://user-images.githubusercontent.com/4587658/88279092-cb611080-cce3-11ea-96f3-c28394e93f63.png)
