### PR TITLE
Increase memory limits from 100mb to 300mb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Increase memory limit from 100mb to 300mb.
+- Increase memory limit from 100mb to 500mb.
 
 ## [0.5.8] - 2020-07-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Increase memory limit from 100mb to 300mb.
+
 ## [0.5.8] - 2020-07-29
 
 ### Changed

--- a/helm/crsync/templates/deployment.yaml
+++ b/helm/crsync/templates/deployment.yaml
@@ -69,7 +69,7 @@ spec:
             memory: 100Mi
           limits:
             cpu: 250m
-            memory: 100Mi
+            memory: 300Mi
         ports:
         - name: metrics
           containerPort: {{ .Values.flags.metricsPort }}

--- a/helm/crsync/templates/deployment.yaml
+++ b/helm/crsync/templates/deployment.yaml
@@ -69,7 +69,7 @@ spec:
             memory: 100Mi
           limits:
             cpu: 250m
-            memory: 300Mi
+            memory: 500Mi
         ports:
         - name: metrics
           containerPort: {{ .Values.flags.metricsPort }}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/15425

With the increased number of tags to retag, docker pull commands inside the container keep dying