### PR TITLE
Fix tags listing from Docker Hub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Handle error responses on listing tags from Docker Hub.
+- Calculate next endpoint based on number of tags in repository.
+
 ## [0.5.9] - 2021-01-28
 
 ### Changed

--- a/cmd/sync/flag.go
+++ b/cmd/sync/flag.go
@@ -24,6 +24,7 @@ const (
 	flagIncludePrivateRepositories = "include-private-repositories"
 	flagMetricsPort                = "metrics-port"
 	flagQuayAPIToken               = "quay-api-token" // nolint
+	flagSyncInterval               = "sync-interval"
 )
 
 type flag struct {
@@ -38,6 +39,7 @@ type flag struct {
 	IncludePrivateRepositories bool
 	MetricsPort                int
 	QuayAPIToken               string
+	SyncInterval               int
 }
 
 func (f *flag) Init(cmd *cobra.Command) {
@@ -52,6 +54,8 @@ func (f *flag) Init(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&f.IncludePrivateRepositories, flagIncludePrivateRepositories, false, "Whether to synchronize private repositories.")
 	cmd.Flags().IntVar(&f.MetricsPort, flagMetricsPort, 0, "Port on which metrics are served. 0 disables metrics.")
 	cmd.Flags().StringVar(&f.QuayAPIToken, flagQuayAPIToken, "", fmt.Sprintf(`Quay container registry API token. Defaults to %s environment variable.`, env.QuayAPIToken))
+	cmd.Flags().IntVar(&f.SyncInterval, flagSyncInterval, 30, "Interval(seconds) between two syncs when running in a loop.")
+
 }
 
 func (f *flag) Validate() error {
@@ -78,9 +82,6 @@ func (f *flag) Validate() error {
 	}
 	if f.SrcRegistryName == sourceRegistryName && f.QuayAPIToken == "" {
 		f.QuayAPIToken = os.Getenv(env.QuayAPIToken)
-	}
-	if f.SrcRegistryName == sourceRegistryName && f.QuayAPIToken == "" {
-		return microerror.Maskf(invalidFlagError, "--%s must not be empty", flagQuayAPIToken)
 	}
 
 	return nil

--- a/cmd/sync/runner.go
+++ b/cmd/sync/runner.go
@@ -185,7 +185,7 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 			fmt.Printf("\nTook %s\n", time.Since(start))
 		}
 
-		time.Sleep(10 * time.Second)
+		time.Sleep(time.Duration(r.flag.SyncInterval) * time.Second)
 	}
 }
 

--- a/pkg/dockerhub/dockerhub.go
+++ b/pkg/dockerhub/dockerhub.go
@@ -13,6 +13,7 @@ import (
 const (
 	authEndpoint    = "https://hub.docker.com"
 	registryAddress = "https://index.docker.io" // nolint
+	tagsPerPage     = 10
 )
 
 type Config struct {
@@ -71,9 +72,11 @@ func (d *DockerHub) ListRepositories() ([]string, error) {
 }
 
 func (d *DockerHub) ListTags(repository string) ([]string, error) {
-	endpoint := fmt.Sprintf("%s/v2/repositories/%s/tags/", authEndpoint, repository)
+	page := 1
+	endpoint := fmt.Sprintf("%s/v2/repositories/%s/tags/?page=%d", authEndpoint, repository, page)
 
 	type dockerHubTags struct {
+		Count   int    `json:"count"`
 		Next    string `json:"next"`
 		Results []struct {
 			Name string `json:"name"`
@@ -114,11 +117,13 @@ func (d *DockerHub) ListTags(repository string) ([]string, error) {
 				tags = append(tags, tag.Name)
 			}
 
-			if tagsJSON.Next == "" || tagsJSON.Next == nextEndpoint {
+			numOfPages := (tagsJSON.Count / tagsPerPage) + 1
+			if page == numOfPages {
 				break
 			}
 
 			nextEndpoint = tagsJSON.Next
+			page += 1
 		}
 	}
 

--- a/pkg/dockerhub/dockerhub.go
+++ b/pkg/dockerhub/dockerhub.go
@@ -109,7 +109,7 @@ func (d *DockerHub) ListTags(repository string) ([]string, error) {
 			}
 
 			if resp.StatusCode != http.StatusOK {
-				return []string{}, microerror.Maskf(executionFailedError, fmt.Sprintf("Expected status code %#d, got %#d: %v", http.StatusOK, resp.StatusCode, string(body)))
+				return []string{}, microerror.Maskf(executionFailedError, fmt.Sprintf("Expected status code '%d', got '%d': %v", http.StatusOK, resp.StatusCode, string(body)))
 			}
 
 			err = json.Unmarshal(body, &tagsJSON)

--- a/pkg/dockerhub/dockerhub.go
+++ b/pkg/dockerhub/dockerhub.go
@@ -108,6 +108,10 @@ func (d *DockerHub) ListTags(repository string) ([]string, error) {
 				return []string{}, microerror.Mask(err)
 			}
 
+			if resp.StatusCode != http.StatusOK {
+				return []string{}, microerror.Maskf(executionFailedError, fmt.Sprintf("Expected status code %#d, got %#d: %v", http.StatusOK, resp.StatusCode, string(body)))
+			}
+
 			err = json.Unmarshal(body, &tagsJSON)
 			if err != nil {
 				return []string{}, microerror.Mask(err)


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/15425

- Handle error responses on listing tags from Docker Hub.
- Calculate next endpoint based on number of tags in repository.