### PR TITLE
Limit number of jobs executed in parallel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Limit number of retag jobs executed in parallel to 15 to prevent docker from choking.
+- Print overall progress every minute.
+
 ### Fixed
 
 - Fix error when destination (Docker Hub) repository doesn't have any tags yet.

--- a/cmd/sync/runner.go
+++ b/cmd/sync/runner.go
@@ -30,9 +30,12 @@ const (
 	sourceRegistryName = "quay.io"
 
 	getTagsWorkersNum = 100
-	// Docker limits the number of parallel pushes to 5. This limit is 15
-	// to have 10 images pulled and ready to be pushed.
-	retagWorkesNum = 15
+	// Docker limits the number of parallel pushes to 5. This limit is
+	// 4 because there is no real speed gain when going above that and we
+	// put unnecessary pressure on the docker daemon. This gives also one
+	// slot left is there is another docker push operation executed on
+	// the node.
+	retagWorkesNum = 4
 	listBurst      = 1
 	// Docker limits the number of parallel pushes to 5 anyway.
 	pullPushBurst = 10
@@ -86,7 +89,7 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 					return
 				case <-ticker.C:
 					fmt.Printf(
-						"*** Progress: repositories: [%d/%d] tags: [%d/%d] time elapsed: %s\n",
+						"*** Progress: repositories: [%d/%d] tags: [%d/%d] time elapsed: %s ***\n",
 						r.progressReposDone, r.progressReposTotal,
 						r.progressTagsDone, r.progressTagsTotal,
 						time.Since(start).Round(time.Second),

--- a/cmd/sync/runner.go
+++ b/cmd/sync/runner.go
@@ -265,15 +265,15 @@ func (r *runner) sync(ctx context.Context, srcRegistry, dstRegistry registry.Int
 	retagWG := sync.WaitGroup{}
 
 	for i := 0; i < getTagsWorkersNum; i++ {
+		getTagsWG.Add(1)
 		go func(ctx context.Context) {
-			getTagsWG.Add(1)
 			defer getTagsWG.Done()
 			r.processGetTagsJobs(ctx, getTagsJobCh, retagJobCh)
 		}(ctx)
 	}
 	for i := 0; i < retagWorkesNum; i++ {
+		retagWG.Add(1)
 		go func(ctx context.Context) {
-			retagWG.Add(1)
 			defer retagWG.Done()
 			r.processRetagJobs(ctx, retagJobCh)
 		}(ctx)


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/17200

After changes in #117 there quite a few repos unlocked. Including `giantswarm/giantswarm` with >1.7k not retagged images. Docker on my machine couldn't survive >200 parallel jobs and there is apparently docker limit of 5 parallel pushes.

See this Slack thread for details: https://gigantic.slack.com/archives/C010L893ZFW/p1621352595013300