### PR TITLE
Fixing the metrics path "/metrics"

### DIFF
--- a/helm/crsync/templates/service.yaml
+++ b/helm/crsync/templates/service.yaml
@@ -7,9 +7,8 @@ metadata:
     {{- include "labels.common" . | nindent 4 }}
     giantswarm.io/monitoring: "true"
   annotations:
-    giantswarm.io/monitoring-path: "metrics"
+    giantswarm.io/monitoring-path: "/metrics"
     giantswarm.io/monitoring-port: {{ .Values.flags.metricsPort | quote }}
-    prometheus.io/scrape: "true"
 spec:
   ports:
     - name: metrics


### PR DESCRIPTION
crsync is sometimes having timeout issues, we identified the pod was running but logs clearly showed images couldn't be synced:

```
*** Progress: repositories: [355930/172] tags: [255/255] time elapsed: 191h42m0s ***

Logging in source registry...
Logging in destination registry...

Sync error:
Post "https://hub.docker.com/v2/users/login/": dial tcp: i/o timeout
	/root/project/pkg/dockerhub/dockerhub.go:52
	/root/project/pkg/registry/registry.go:52
	/root/project/pkg/registry/decorated_registry.go:54
	/root/project/cmd/sync/runner.go:241
	/root/project/cmd/sync/runner.go:216

*** Progress: repositories: [355930/172] tags: [255/255] time elapsed: 191h43m0s ***

Logging in source registry...
Logging in destination registry...
*** Progress: repositories: [355930/172] tags: [255/255] time elapsed: 191h44m0s ***

Sync error:
Post "https://hub.docker.com/v2/users/login/": dial tcp: i/o timeout
	/root/project/pkg/dockerhub/dockerhub.go:52
	/root/project/pkg/registry/registry.go:52
	/root/project/pkg/registry/decorated_registry.go:54
	/root/project/cmd/sync/runner.go:241
	/root/project/cmd/sync/runner.go:216
```

Fixing the path "/metrics" should work.