### PR TITLE
Configure gsoci.azurecr.io as the registry to use by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Configure `gsoci.azurecr.io` as the default container image registry.
+
 ## [0.9.1] - 2023-12-05
 
 ### Fixed
@@ -128,7 +132,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Measure tag count in case of **no** errors.
-
 
 ## [0.5.0] - 2020-07-21
 

--- a/helm/crsync/values.yaml
+++ b/helm/crsync/values.yaml
@@ -4,7 +4,7 @@ flags:
   metricsPort: 8000
 
 destinationRegistry:
-  name: docker.io
+  name: gsoci.azurecr.io
   credentials:
     user: ""
     # base64 encoded password


### PR DESCRIPTION
Towards

- https://github.com/giantswarm/roadmap/issues/3017

This PR replaces any occurrence of `docker.io` in `values.yaml` files with `gsoci.azurecr.io`,
to make the new ACR registry the default one.
