### PR TITLE
Add settings for dind to deployment - move kyverno policy-exception

### DIFF
--- a/helm/crsync/templates/deployment.yaml
+++ b/helm/crsync/templates/deployment.yaml
@@ -34,6 +34,16 @@ spec:
         seccompProfile:
           type: RuntimeDefault
       containers:
+      - image: docker:26-dind
+        imagePullPolicy: IfNotPresent
+        name: dind
+        securityContext:
+          privileged: true
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /var/run/
+          name: socket-volume
       - args:
         - sync
         - --dst-name={{ .Values.destinationRegistry.name }}
@@ -65,10 +75,10 @@ spec:
         name: {{ include "resource.default.name"  . }}
         securityContext:
           seccompProfile:
-            type: RuntimeDefault 
+            type: RuntimeDefault
         volumeMounts:
-        - mountPath: /var/run/docker.sock
-          name: docker-socket
+        - mountPath: /var/run/
+          name: socket-volume
         resources:
           requests:
             cpu: 100m
@@ -82,6 +92,6 @@ spec:
       serviceAccount: {{ include "resource.default.name"  . }}
       serviceAccountName: {{ include "resource.default.name"  . }}
       volumes:
-      - name: docker-socket
-        hostPath:
-          path: /var/run/docker.sock
+      - name: socket-volume
+        emptyDir: {}
+

--- a/helm/crsync/templates/kyverno-policy-exception.yaml
+++ b/helm/crsync/templates/kyverno-policy-exception.yaml
@@ -3,7 +3,7 @@ apiVersion: kyverno.io/v2alpha1
 kind: PolicyException
 metadata:
   name: {{ include "resource.default.name"  . }}
-  namespace: {{ include "resource.default.namespace"  . }}
+  namespace: giantswarm
   labels:
     {{- include "labels.common" . | nindent 4 }}
 spec:
@@ -32,8 +32,8 @@ spec:
     - autogen-cronjob-require-drop-all
     - autogen-adding-capabilities-strict
     - autogen-cronjob-adding-capabilities-strict
-  - policyName: disallow-privilege-escalation 
-    ruleNames: 
+  - policyName: disallow-privilege-escalation
+    ruleNames:
     - privilege-escalation
     - autogen-privilege-escalation
   match:


### PR DESCRIPTION
crsync requires docker which is not available on newer clusters running containerd

This adds docker-in-docker (dind) to allow crsync to operate correctly

Also requires moving the kyverno policy exception to the giantswarm namespace